### PR TITLE
rename "predicate" property to "if"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If the predicate evaluation fails, or the predicate returns non-boolean result, 
 
 |Name|Description|Type|Default|Valid values|Importance|
 |---|---|---|---|---|---|
-|`predicate`|The predicate to be evaluated on each message|string|-|Any valid ECMAScript expression that evaluates to a boolean|HIGH
+|`if`|The predicate to be evaluated on each message|string|-|Any valid ECMAScript expression that evaluates to a boolean|HIGH
 
 ### Examples
 
@@ -32,7 +32,7 @@ Assume the following configuration:
 ```json
 "transforms": "dropValue",
 "transforms.dropValue.type":"com.redhat.insights.kafka.connect.transforms.DropIf$Value",
-"transforms.dropValue.predicate": "record.value().get('country') == 'CZ'"
+"transforms.dropValue.if": "record.value().get('country') == 'CZ'"
 ```
 
 Example 1
@@ -84,7 +84,7 @@ If the predicate evaluation fails, or the predicate returns non-boolean result, 
 
 |Name|Description|Type|Default|Valid values|Importance|
 |---|---|---|---|---|---|
-|`predicate`|The predicate to be evaluated on each message|string|-|Any valid ECMAScript expression that evaluates to a boolean|HIGH
+|`if`|The predicate to be evaluated on each message|string|-|Any valid ECMAScript expression that evaluates to a boolean|HIGH
 
 ### Examples
 
@@ -93,7 +93,7 @@ Assume the following configuration:
 ```json
 "transforms": "filter",
 "transforms.filter.type":"com.redhat.insights.kafka.connect.transforms.Filter",
-"transforms.filter.predicate": "record['value']['country'] === 'CZ'"
+"transforms.filter.if": "record['value']['country'] === 'CZ'"
 ```
 
 Example 1

--- a/src/main/java/com/redhat/insights/kafka/connect/transforms/BooleanPredicateTransform.java
+++ b/src/main/java/com/redhat/insights/kafka/connect/transforms/BooleanPredicateTransform.java
@@ -13,7 +13,8 @@ import java.util.Map;
 
 abstract class BooleanPredicateTransform<T extends ConnectRecord<T>> extends AbstractTransformation<T> {
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-    protected static final String CONFIG_FIELD = "predicate";
+    protected static final String CONFIG_FIELD_LEGACY = "predicate";
+    protected static final String CONFIG_FIELD = "if";
     private volatile String predicate;
     private volatile ScriptEngine engine;
 
@@ -24,11 +25,20 @@ abstract class BooleanPredicateTransform<T extends ConnectRecord<T>> extends Abs
     @Override
     public void configure(Map<String, ?> configs, AbstractConfig config) {
         this.predicate = config.getString(CONFIG_FIELD);
+
+        if (this.predicate == null) {
+            this.predicate = config.getString(CONFIG_FIELD_LEGACY);
+        }
+
         final ScriptEngineManager manager = new ScriptEngineManager();
         this.engine = manager.getEngineByName("JavaScript");
     }
 
     protected boolean evalPredicate(T record) {
+        if (this.predicate == null) {
+            return true;
+        }
+
         final Bindings bindings = new SimpleBindings();
         bindings.put("record", record);
 

--- a/src/main/java/com/redhat/insights/kafka/connect/transforms/DropIf.java
+++ b/src/main/java/com/redhat/insights/kafka/connect/transforms/DropIf.java
@@ -9,9 +9,12 @@ import org.apache.kafka.connect.connector.ConnectRecord;
 public abstract class DropIf<T extends ConnectRecord<T>> extends BooleanPredicateTransform<T> implements KeyOrValueTransformation<T>  {
 
     public DropIf(){
-        super(new ConfigDef().define(CONFIG_FIELD, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH,
-                        "ECMAScript predicate to be evaluated for each message. If the predicate evaluates to true the message key/value is dropped."));
-
+        super(new ConfigDef()
+            .define(CONFIG_FIELD, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH,
+                "ECMAScript predicate to be evaluated for each message. If the predicate evaluates to true the message key/value is dropped.")
+            // https://cwiki.apache.org/confluence/display/KAFKA/KIP-585
+            .define(CONFIG_FIELD_LEGACY, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH,
+                "Alias of the 'if' property. The alias exists for backward compatibility."));
     }
 
     @Override

--- a/src/main/java/com/redhat/insights/kafka/connect/transforms/Filter.java
+++ b/src/main/java/com/redhat/insights/kafka/connect/transforms/Filter.java
@@ -9,8 +9,12 @@ import org.apache.kafka.connect.connector.ConnectRecord;
 public class Filter<T extends ConnectRecord<T>> extends BooleanPredicateTransform<T> {
 
     public Filter(){
-        super(new ConfigDef().define(CONFIG_FIELD, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH,
-                "ECMAScript predicate to be evaluated for each message. If the predicate evaluates to true the message is dropped."));
+        super(new ConfigDef()
+            .define(CONFIG_FIELD, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH,
+                "ECMAScript predicate to be evaluated for each message. If the predicate evaluates to true the message is dropped.")
+            // https://cwiki.apache.org/confluence/display/KAFKA/KIP-585
+            .define(CONFIG_FIELD_LEGACY, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH,
+                "Alias of the 'if' property. The alias exists for backward compatibility."));
     }
 
     @Override

--- a/src/test/java/com/redhat/insights/kafka/connect/transforms/DropIfTest.java
+++ b/src/test/java/com/redhat/insights/kafka/connect/transforms/DropIfTest.java
@@ -35,7 +35,7 @@ public class DropIfTest {
 
     @Test
     public void testValuePositive() {
-        final Map<String, String> props = Collections.singletonMap("predicate", "record.value().get('number') == 1");
+        final Map<String, String> props = Collections.singletonMap("if", "record.value().get('number') == 1");
         final SinkRecord record = new SinkRecord("test", 0, null, null, null, Collections.singletonMap("number", 1), 0);
 
         transformValue.configure(props);
@@ -46,7 +46,7 @@ public class DropIfTest {
 
     @Test
     public void testValueNegative() {
-        final Map<String, String> props = Collections.singletonMap("predicate", "record.value().get('number') == 1");
+        final Map<String, String> props = Collections.singletonMap("if", "record.value().get('number') == 1");
         final Map<String, Object> value = Collections.singletonMap("number", 2);
         final SinkRecord record = new SinkRecord("test", 0, null, null, null, value, 0);
 
@@ -59,7 +59,7 @@ public class DropIfTest {
 
     @Test
     public void testValueBasedOnHeaderPositive() {
-        final Map<String, String> props = Collections.singletonMap("predicate", "record.headers().lastWithName('request_id').value() == '1'");
+        final Map<String, String> props = Collections.singletonMap("if", "record.headers().lastWithName('request_id').value() == '1'");
         final Headers headers = new ConnectHeaders().add("request_id", "1", null);
         final SinkRecord record = new SinkRecord("test", 0, null, null, null, "value", 0, null, TimestampType.NO_TIMESTAMP_TYPE, headers);
 
@@ -71,7 +71,7 @@ public class DropIfTest {
 
     @Test
     public void testKeyPositive() {
-        final Map<String, String> props = Collections.singletonMap("predicate", "record.key() == 'abc'");
+        final Map<String, String> props = Collections.singletonMap("if", "record.key() == 'abc'");
         final SinkRecord record = new SinkRecord("test", 0, null, "abc", null, "value", 0);
 
         transformKey.configure(props);
@@ -82,7 +82,7 @@ public class DropIfTest {
 
     @Test
     public void testKeyNegative() {
-        final Map<String, String> props = Collections.singletonMap("predicate", "record.key() == 'abc'");
+        final Map<String, String> props = Collections.singletonMap("if", "record.key() == 'abc'");
         final String key = "def";
         final SinkRecord record = new SinkRecord("test", 0, null, key, null, "value", 0);
 
@@ -95,10 +95,49 @@ public class DropIfTest {
 
     @Test(expected = ConnectException.class)
     public void testExceptionThrownOnInvalidScript() {
-        final Map<String, String> props = Collections.singletonMap("predicate", "record.key(");
+        final Map<String, String> props = Collections.singletonMap("if", "record.key(");
         final SinkRecord record = new SinkRecord("test", 0, null, "key", null, "value", 0);
 
         transformKey.configure(props);
         transformKey.apply(record);
+    }
+
+    @Test
+    public void testDefaultPredicate() {
+        final Map<String, String> props = Collections.emptyMap();
+        final Map<String, Object> value = Collections.singletonMap("number", 2);
+        final SinkRecord record = new SinkRecord("test", 0, null, null, null, value, 0);
+
+        transformValue.configure(props);
+        final SinkRecord result = transformValue.apply(record);
+
+        assertNotNull(result);
+        assertEquals(result.value(), null);
+    }
+
+    @Test
+    public void testLegacyProperty() {
+        final Map<String, String> props = Collections.singletonMap("predicate", "record.value().get('number') == 1");
+        final Map<String, Object> value = Collections.singletonMap("number", 2);
+        final SinkRecord record = new SinkRecord("test", 0, null, null, null, value, 0);
+
+        transformValue.configure(props);
+        final SinkRecord result = transformValue.apply(record);
+
+        assertNotNull(result);
+        assertEquals(result.value(), value);
+    }
+
+    @Test
+    public void testPredicatePriority() {
+        final Map<String, String> props = Map.of("predicate", "record.value().get('number') == 2", "if", "record.value().get('number') == 1");
+        final Map<String, Object> value = Collections.singletonMap("number", 2);
+        final SinkRecord record = new SinkRecord("test", 0, null, null, null, value, 0);
+
+        transformValue.configure(props);
+        final SinkRecord result = transformValue.apply(record);
+
+        assertNotNull(result);
+        assertEquals(result.value(), value);
     }
 }

--- a/src/test/java/com/redhat/insights/kafka/connect/transforms/FilterTest.java
+++ b/src/test/java/com/redhat/insights/kafka/connect/transforms/FilterTest.java
@@ -27,7 +27,7 @@ public class FilterTest {
 
     @Test
     public void testPredicateMatch() {
-        final Map<String, String> props = Collections.singletonMap("predicate", "!!record.value().get('requiredFact')");
+        final Map<String, String> props = Collections.singletonMap("if", "!!record.value().get('requiredFact')");
         Map<String, Integer> value = Collections.singletonMap("requiredFact", 1);
         final SinkRecord record = new SinkRecord("test", 0, null, null, null, value, 0);
 
@@ -40,7 +40,7 @@ public class FilterTest {
 
     @Test
     public void testNegative() {
-        final Map<String, String> props = Collections.singletonMap("predicate", "!!record.value().get('requiredFact')");
+        final Map<String, String> props = Collections.singletonMap("if", "!!record.value().get('requiredFact')");
         final SinkRecord record = new SinkRecord("test", 0, null, null, null, Collections.singletonMap("otherFact", 1), 0);
 
         transform.configure(props);
@@ -52,7 +52,7 @@ public class FilterTest {
 
     @Test(expected = ConnectException.class)
     public void testExceptionThrownOnInvalidScript() {
-        final Map<String, String> props = Collections.singletonMap("predicate", "record.key(");
+        final Map<String, String> props = Collections.singletonMap("if", "record.key(");
         final SinkRecord record = new SinkRecord("test", 0, null, "key", null, "value", 0);
 
         transform.configure(props);


### PR DESCRIPTION
Due to KIP-585 SMTs can no longer use a property named "predicate".
Therefore, the predicate property has been renamed to "if".
The "predicate" is still retained as an alias for backward compatibility with pre-Kafka 2.6.0 environments.