### PR TITLE
Add nashorn-core dependency for JDK17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [11, 17]
     steps:
       - uses: actions/checkout@v2
 
@@ -20,10 +23,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.Java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.Java }}
 
       - name: Build with Maven
         run: mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,13 @@
             <version>${version.jackson}</version>
         </dependency>
 
+        <!-- JDK17 requires new javascript engine -->
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.4</version>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -107,13 +114,13 @@
             <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.25</version>
             <scope>test</scope>
           </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/redhat/insights/kafka/connect/transforms/BooleanPredicateTransform.java
+++ b/src/main/java/com/redhat/insights/kafka/connect/transforms/BooleanPredicateTransform.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import javax.script.*;
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
+import org.openjdk.nashorn.api.scripting.*;
 
 abstract class BooleanPredicateTransform<T extends ConnectRecord<T>> extends AbstractTransformation<T> {
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -30,8 +31,8 @@ abstract class BooleanPredicateTransform<T extends ConnectRecord<T>> extends Abs
             this.predicate = config.getString(CONFIG_FIELD_LEGACY);
         }
 
-        final ScriptEngineManager manager = new ScriptEngineManager();
-        this.engine = manager.getEngineByName("JavaScript");
+        final NashornScriptEngineFactory manager = new NashornScriptEngineFactory();
+        this.engine = manager.getScriptEngine();
     }
 
     protected boolean evalPredicate(T record) {


### PR DESCRIPTION
nashorn was removed in JDK15 so we have to replace it with something. Found nashorn-core which should work with JDK17 and, in particular, the new AMQ Streams 2.4 compatible images.