### PR TITLE
fix: Proper use of Nashorn for JDK 17

### DIFF
--- a/src/main/java/com/redhat/insights/kafka/connect/transforms/BooleanPredicateTransform.java
+++ b/src/main/java/com/redhat/insights/kafka/connect/transforms/BooleanPredicateTransform.java
@@ -10,7 +10,6 @@ import org.slf4j.LoggerFactory;
 import javax.script.*;
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
-import org.openjdk.nashorn.api.scripting.*;
 
 abstract class BooleanPredicateTransform<T extends ConnectRecord<T>> extends AbstractTransformation<T> {
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());


### PR DESCRIPTION
The scripting engine is called differently than originally thought when using nashorn-core in JDK 17